### PR TITLE
one time binding rocks

### DIFF
--- a/_posts/2016-02-25-one-time-binding.md
+++ b/_posts/2016-02-25-one-time-binding.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title:  "One Time Binding"
+date:   2016-02-25 11:50:00
+category: til
+tags: [angular, performance]
+---
+
+TIL that angular 1.3 and onwards has a `one-time-bind` option to pass to interpolated expressions in templates, which tells angular that the data is not expected to change.
+
+The one-time-bind option tells angular not to add a watcher to the interpolated property, *effectively disabling 2-way binding for the property.* If you know a `$scope` property is not expected to change during the lifetime of the view, why waste the extra time during the `$digest()` cycle to dirty-check the property?
+
+__Example:__
+
+{% highlight html %}
+<!-- Normal 2-way binding (creates a watcher on $scope.name) -->
+<span>Hello, {%raw%} {{ name }} {%endraw%}</span>
+
+<!-- one-time binding (no watcher created) -->
+<span>Hello, {%raw%} {{ ::name }} {%endraw%}</span>
+
+{% endhighlight %}
+
+The double semicolon `::` lets angular know that it should do a one time binding of the scope property to the template. If `$scope.name` changes in the second situation above, the change will not be reflected in the template.
+
+Another reason to upgrade to angular 1.3!
+
+[ng-bind]: https://docs.angularjs.org/api/ng/directive/ngBind

--- a/_posts/2016-02-25-one-time-binding.md
+++ b/_posts/2016-02-25-one-time-binding.md
@@ -6,7 +6,7 @@ category: til
 tags: [angular, performance]
 ---
 
-TIL that angular 1.3 and onwards has a [one-time-bind][otb]{:target="_blank"} option to pass to interpolated expressions in templates, which tells angular that the data is not expected to change.
+TIL that angular 1.3 and onwards has a [one-time-bind][otb]{:target="_blank"} option to pass to interpolated expressions, which tells angular that the data is not expected to change.
 
 The one-time-bind option tells angular not to add a watcher to the interpolated property, *effectively disabling 2-way binding for the property.* If you know a `$scope` property is not expected to change during the lifetime of the view, why waste the extra time during the `$digest()` cycle to dirty-check the property?
 

--- a/_posts/2016-02-25-one-time-binding.md
+++ b/_posts/2016-02-25-one-time-binding.md
@@ -6,7 +6,7 @@ category: til
 tags: [angular, performance]
 ---
 
-TIL that angular 1.3 and onwards has a `one-time-bind` option to pass to interpolated expressions in templates, which tells angular that the data is not expected to change.
+TIL that angular 1.3 and onwards has a [one-time-bind][otb]{:target="_blank"} option to pass to interpolated expressions in templates, which tells angular that the data is not expected to change.
 
 The one-time-bind option tells angular not to add a watcher to the interpolated property, *effectively disabling 2-way binding for the property.* If you know a `$scope` property is not expected to change during the lifetime of the view, why waste the extra time during the `$digest()` cycle to dirty-check the property?
 
@@ -25,4 +25,4 @@ The double semicolon `::` lets angular know that it should do a one time binding
 
 Another reason to upgrade to angular 1.3!
 
-[ng-bind]: https://docs.angularjs.org/api/ng/directive/ngBind
+[otb]: https://docs.angularjs.org/guide/expression#one-time-binding


### PR DESCRIPTION
### POST TOPIC

Angular one time binding, to prevent unnecessary watchers from being created.
### "Post" Definition of Done:
- [x] Proofread post for spelling and grammatical issues (copy in to word processor to see spelling issues).
- [x] Click all links to make sure they link to the intended pages.
- [x] Review formatting to ensure the post is easy to read.
- [x] Confirm new post template matches the Jekyll naming conventions YYYY-MM-DD-Post-Name.markdown
- [x] Confirm header is updated.
- [x] Make sure all links are target="_blank"-ified (this should eventually become javascript).
### How are you feeling?

Deace. It was a long week at work (was sick on monday, plus school this week), but I really got to dig in to some cool stuff that I hadn't really used before in angular. 
