### PR TITLE
tag and category pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,10 +39,12 @@ og_image                 : # Open Graph/Twitter default site image
 # For specifying social profiles
 # - https://developers.google.com/structured-data/customize/social-profiles
 social:
-  type                   : # Person or Organization (defaults to Person)
-  name                   : # If the user or organization name differs from the site's name
+  type                   : "Person" # Person or Organization (defaults to Person)
+  name                   : "Brian Ambielli" # If the user or organization name differs from the site's name
   links: # An array of links to social media profiles
-
+    - "https://www.linkedin.com/in/bambielli"
+    - "https://twitter.com/bambielli"
+    - "https://facebook.com/bambielli"
 # Analytics
 analytics:
   provider               : "google" # false (default), "google", "google-universal", "custom"

--- a/_pages/category-archive.html
+++ b/_pages/category-archive.html
@@ -1,0 +1,24 @@
+---
+layout: archive
+permalink: /categories/
+title: "Posts by Category"
+author_profile: false
+---
+
+{% include base_path %}
+
+<!-- push TILs to an array with general posts -->
+{% assign __full_array = site.posts %}
+{% for post in site.til %}
+  {% assign __full_array = __full_array | push: post %}
+{% endfor %}
+
+{% include group-by-array collection=__full_array field="categories" %}
+
+{% for category in group_names %}
+  {% assign posts = group_items[forloop.index0] %}
+  <h2 id="{{ category | slugify }}" class="archive__subtitle">{{ category }}</h2>
+  {% for post in posts %}
+    {% include archive-single.html %}
+  {% endfor %}
+{% endfor %}

--- a/_pages/tag-archive.html
+++ b/_pages/tag-archive.html
@@ -7,8 +7,8 @@ author_profile: false
 
 {% include base_path %}
 
+<!-- push TILs to an array with general posts -->
 {% assign __full_array = site.posts %}
-<!-- push TILs to the array -->
 {% for post in site.til %}
   {% assign __full_array = __full_array | push: post %}
 {% endfor %}

--- a/_pages/tag-archive.html
+++ b/_pages/tag-archive.html
@@ -1,0 +1,24 @@
+---
+layout: archive
+permalink: /tags/
+title: "Posts by Tags"
+author_profile: false
+---
+
+{% include base_path %}
+
+{% assign __full_array = site.posts %}
+<!-- push TILs to the array -->
+{% for post in site.til %}
+  {% assign __full_array = __full_array | push: post %}
+{% endfor %}
+
+{% include group-by-array collection=__full_array field="tags" %}
+
+{% for tag in group_names %}
+  {% assign posts = group_items[forloop.index0] %}
+  <h2 id="{{ tag | slugify }}" class="archive__subtitle">{{ tag }}</h2>
+  {% for post in posts %}
+    {% include archive-single.html %}
+  {% endfor %}
+{% endfor %}


### PR DESCRIPTION
### POST TOPIC

Adding pages that display all posts (both normal post and TIL style posts) grouped by tag and category. 
These pages are linked to by the clickable tag and category buttons at the bottom of each post.
### "Post" Definition of Done:
- [x] Proofread post for spelling and grammatical issues (copy in to word processor to see spelling issues).
- [x] Click all links to make sure they link to the intended pages.
- [x] Review formatting to ensure the post is easy to read.
- [x] Confirm new post template matches the Jekyll naming conventions YYYY-MM-DD-Post-Name.markdown
- [x] Confirm header is updated.
- [x] Make sure all links are target="_blank"-ified (this should eventually become javascript).
### How are you feeling?

Quite good! This is a nice addition. Manipulating arrays in Jekyll is a bit weird, but I checked out the source code for the group-by-array include which helped immensely.
